### PR TITLE
App Remote monitoring fix

### DIFF
--- a/web/lib/service.py
+++ b/web/lib/service.py
@@ -124,7 +124,7 @@ class Service(Thread):
             self.worker_run(timeout=0.1)
         except ServiceRestartSignal:
             log.info(f"{self.name}: Service requested restart.")
-            self._holdoff.reset(delay=1)
+            self._holdoff.reset(delay=10)
             self.state = RunState.Stopping
         except Exception:
             log.exception(f"{self.name}: Unexpected exception while running worker")


### PR DESCRIPTION
A very slight change to how quickly the service class will attempt to restart. Right now when you try to stream the camera from the AnkerMake phone app it won't work because although the PPPPService is closed it is restarted after only a second. This means the AnkerMake app is never able to secure a connection to the camera. By adjusting the restart delay from 1 second to 10 seconds, the app has time to connect and stream the video.