### PR TITLE
Allow setting nozzle and heatbed temperature via web interface

### DIFF
--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -5,7 +5,7 @@ $(function () {
     $("#copyYear").text(new Date().getFullYear());
 
     /**
-     * Handle modal being shown
+     * Handle modal for progress bar being shown
      */
     var popupModalDom = document.getElementById("popupModal");
     var popupModalBS = new bootstrap.Modal(popupModalDom);
@@ -264,6 +264,7 @@ $(function () {
             url,
             badge = null,
             open = null,
+            opened = null,
             close = null,
             error = null,
             message = null,
@@ -275,11 +276,13 @@ $(function () {
             this.badge = badge;
             this.reconnect = reconnect;
             this.open = open;
+            this.opened = opened;
             this.close = close;
             this.error = error;
             this.message = message;
             this.binary = binary;
             this.ws = null;
+            this.is_open = false;
         }
 
         _open() {
@@ -290,7 +293,7 @@ $(function () {
 
         _close() {
             $(this.badge).removeClass("text-bg-warning text-bg-success").addClass("text-bg-danger");
-            console.log(`${this.name} close`);
+            this.is_open = false;
             setTimeout(() => this.connect(), this.reconnect);
             if (this.close)
                 this.close(this.ws);
@@ -299,12 +302,18 @@ $(function () {
         _error() {
             console.log(`${this.name} error`);
             this.ws.close();
+            this.is_open = false;
             if (this.error)
                 this.error(this.ws);
         }
 
         _message(event) {
-            $(this.badge).removeClass("text-bg-danger text-bg-warning").addClass("text-bg-success");
+            if (!this.is_open) {
+                $(this.badge).removeClass("text-bg-danger text-bg-warning").addClass("text-bg-success");
+                this.is_open = true;
+                if (this.opened)
+                    this.opened(event);
+            }
             if (this.message)
                 this.message(event);
         }
@@ -329,6 +338,12 @@ $(function () {
         name: "mqtt socket",
         url: `${location.protocol.replace('http','ws')}//${location.host}/ws/mqtt`,
         badge: "#badge-mqtt",
+
+        opened: function (event) {
+            ["#set-nozzle-temp", "#set-bed-temp"].forEach(function (elem_id) {
+                $(elem_id)[0].disabled = false;
+            });
+        },
 
         message: function (ev) {
             const data = JSON.parse(ev.data);
@@ -357,7 +372,7 @@ $(function () {
                     $("#nozzle-temp").text(`${current}°C`);
                 }
                 if (!isNaN(target)) {
-                    $("#set-nozzle-temp").attr("value", `${target}°C`);
+                    $("#set-nozzle-temp").text(`${target}°C`);
                 }
             } else if (data.commandType == 1004) {
                 // Returns Bed Temp
@@ -367,7 +382,7 @@ $(function () {
                     $("#bed-temp").text(`${current}°C`);
                 }
                 if (!isNaN(target)) {
-                    $("#set-bed-temp").attr("value", `${target}°C`);
+                    $("#set-bed-temp").text(`${target}°C`);
                 }
             } else if (data.commandType == 1006) {
                 // Returns Print Speed
@@ -382,7 +397,7 @@ $(function () {
             }
         },
 
-        close: function () {
+        close: function (ws) {
             $("#print-name").text("");
             $("#time-elapsed").text("00:00:00");
             $("#time-remain").text("00:00:00");
@@ -390,11 +405,15 @@ $(function () {
             $("#progressbar").attr("style", "width: 0%");
             $("#progress").text("0%");
             $("#nozzle-temp").text("0°C");
-            $("#set-nozzle-temp").attr("value", "0°C");
+            $("#set-nozzle-temp").text("0°C");
             $("#bed-temp").text("0°C");
-            $("#set-bed-temp").attr("value", "0°C");
+            $("#set-bed-temp").text("0°C");
             $("#print-speed").text("0mm/s");
             $("#print-layer").text("0 / 0");
+
+            ["#set-nozzle-temp", "#set-bed-temp"].forEach(function (elem_id) {
+                $(elem_id).get(0).disabled = true;
+            });
         },
     });
 
@@ -499,4 +518,112 @@ $(function () {
         sockets.ctrl.ws.send(JSON.stringify({ quality: 1 }));
         return false;
     });
+
+    /**
+     * Handle input modal being shown
+     */
+    var popupModalInputDom = document.getElementById("popupModalInput");
+    var popupModalInputBS = new bootstrap.Modal(popupModalInputDom);
+
+    popupModalInputDom.addEventListener("shown.bs.modal", function (e) {
+        const trigger = e.relatedTarget;
+        const input_id = $(trigger).attr("id");
+        const modalInput = $("#modal-input-elem");
+        setClearModalInput(trigger, $(trigger).attr("title"))
+
+        $("#popupModalInput form").on("submit", function (event) {
+            // do not perform the default submit action
+            event.preventDefault();
+
+            // send the new value to the printer
+            sendNewValueViaMQTT(input_id, modalInput.val());
+
+            // clear modal
+            setClearModalInput(trigger, "", false);
+
+            // remove previous "submit" event handlers
+            $("#popupModalInput form").off("submit");
+
+            // hide modal
+            popupModalInputBS.hide()
+
+            return false;
+        });
+
+        // set input focus
+        modalInput.get(0).focus();
+        modalInput.get(0).select();
+    });
+
+    // from https://stackoverflow.com/a/3561711/15468061
+    function escapeRegex(string) {
+        return string.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
+    }
+
+    function setClearModalInput(trigger, title, doSet = true) {
+        const modalInput = $("#modal-input-elem");
+        let unit = "";
+        // loop over all "data-input-*" attributes
+        [].forEach.call(trigger.attributes, function (attr) {
+            console.debug("attr", attr);
+            if (attr.name.startsWith("data-input-")) {
+                const value = attr.value;
+                const attr_name = attr.name.slice(11);
+                switch (attr_name) {
+                    case "icon-class":
+                        if (doSet) {
+                            $("#popupModalGroup").children().addClass(value);
+                        } else {
+                            $("#popupModalGroup").children().removeClass(value);
+                        }
+                        break;
+                    case "unit":
+                        $("#popupModalInputUnit").text(doSet ? value : "");
+                        unit = value;
+                        break;
+                    default:
+                        if (doSet) {
+                            modalInput.attr(attr_name, value);
+                        } else {
+                            modalInput.removeAttr(attr_name);
+                        }
+                }
+            }
+        });
+        if (doSet) {
+            // special handling of title and value
+            $("#modal-input-inner").text(title);
+            const unit_regex = new RegExp(escapeRegex(unit) + "$");
+            const input_value = $(trigger).text().trim().replace(unit_regex, "").trim();
+            modalInput.val(input_value);
+        } else {
+            $("#modal-input-inner").text("");
+            modalInput.val("");
+        }
+    }
+
+    function sendNewValueViaMQTT(input_id, new_value) {
+        let message_data = {};
+        const new_value_int = (new_value === "") ? 0 : parseInt(new_value);
+        switch (input_id) {
+            case "set-nozzle-temp":
+                message_data = {
+                    commandType: MqttMsgType.ZZ_MQTT_CMD_PREHEAT_CONFIG,
+                    nozzle: new_value_int * 100,
+                    value: 1,     // not sure why and if this is needed
+                };
+                break;
+            case "set-bed-temp":
+                message_data = {
+                    commandType: MqttMsgType.ZZ_MQTT_CMD_PREHEAT_CONFIG,
+                    heatbed: new_value_int * 100,
+                    value: 1,     // not sure why and if this is needed
+                };
+                break;
+        }
+        if (message_data) {
+            sockets.ctrl.ws.send(JSON.stringify({ mqtt: message_data }));
+        }
+    }
+
 });

--- a/static/base.html
+++ b/static/base.html
@@ -25,7 +25,7 @@
             </header>
         </div>
 
-        <!-- Modal -->
+        <!-- Modal for progress bar -->
         <div class="modal fade" id="popupModal" tabindex="-1">
             <div class="modal-dialog modal-dialog-centered">
                 <div class="modal-content">
@@ -39,6 +39,39 @@
                             </div>
                         </div>
                     </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Modal for user input -->
+        <div class="modal fade" id="popupModalInput" tabindex="-1">
+            <div class="modal-dialog modal-dialog-centered modal-sm">
+                <div class="modal-content">
+                    <form>
+                    <div class="modal-body">
+                        <p id="modal-input-inner"></p>
+                        <div class="input-group">
+                            <div class="input-group-text mx-auto" id="popupModalGroup">
+                                <i class="icon"></i>
+                            </div>
+                            <input
+                                id="modal-input-elem"
+                                name="modal-input-name"
+                                class="form-control text-end"
+                                value=""
+                                title=""
+                                aria-label=""
+                                aria-describedby="popupModalGroup"
+                            />
+                            <div class="input-group-text mx-auto" id="popupModalInputUnit">
+                            </div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-primary" id="popupModalInputOK">OK</button>
+                    </div>
+                    </form>
                 </div>
             </div>
         </div>
@@ -81,6 +114,7 @@
         {{ macro.static_script("vendor/bootstrap-5.3.0-alpha3-dist/js/bootstrap.bundle.min.js") }}
         {{ macro.static_script("vendor/cash.min.js") }}
         {{ macro.static_script("vendor/jmuxer.min.js") }}
+        {{ macro.static_script("libflagship.js") }}
         {{ macro.static_script("ankersrv.js") }}
     </body>
 </html>

--- a/static/tabs/home.html
+++ b/static/tabs/home.html
@@ -97,18 +97,24 @@
                                     >
                                         0°C
                                     </span>
-                                    <input
-                                        type="text"
+                                    <button
+                                        type="button" class="btn btn-secondary"
                                         id="set-nozzle-temp"
                                         name="set-nozzle-temp"
-                                        class="form-control text-center"
-                                        value="0°C"
+                                        class="input-group-text"
                                         title="Target Nozzle Temperature"
                                         aria-label="Target Nozzle Temperature"
                                         aria-describedby="nozzleGroup"
+                                        data-bs-toggle="modal" data-bs-target="#popupModalInput"
+                                        data-input-type="number"
+                                        data-input-min="0"
+                                        data-input-max="300"
+                                        data-input-icon-class="icon-hotend"
+                                        data-input-unit="°C"
                                         disabled
-                                        readonly
-                                    />
+                                    >
+                                        0°C
+                                    </button>
                                 </div>
                             </div>
                             <div class="col-md-6">
@@ -124,18 +130,24 @@
                                     >
                                         0°C
                                     </span>
-                                    <input
-                                        type="text"
+                                    <button
+                                        type="button" class="btn btn-secondary"
                                         id="set-bed-temp"
                                         name="set-bed-temp"
-                                        class="form-control text-center"
-                                        value="0°C"
+                                        class="input-group-text"
                                         title="Target Bed Temperature"
                                         aria-label="Target Bed Temperature"
                                         aria-describedby="bedGroup"
+                                        data-bs-toggle="modal" data-bs-target="#popupModalInput"
+                                        data-input-type="number"
+                                        data-input-min="0"
+                                        data-input-max="100"
+                                        data-input-icon-class="icon-bed"
+                                        data-input-unit="°C"
                                         disabled
-                                        readonly
-                                    />
+                                    >
+                                        0°C
+                                    </button>
                                 </div>
                             </div>
                         </div>

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -134,6 +134,10 @@ def ctrl(sock):
     while True:
         msg = json.loads(sock.receive())
 
+        if "mqtt" in msg:
+            with app.svc.borrow("mqttqueue") as mq:
+                mq.client.command(msg["mqtt"])
+
         if "light" in msg:
             with app.svc.borrow("videoqueue") as vq:
                 vq.api_light_state(msg["light"])


### PR DESCRIPTION
This PR is a replacement for PR #6 and is a proposal for allowing to set the nozzle and heatbed temperature from the web interface. In detail the changes are:
* Allow set the nozzle and heatbed temperature by using the existing "home" page and adding a parameterized bootstrap modal. If the MQTT connection is not established yet, the target temperatures cannot be set (buttons disabled).
* Fix the occasional displaying of "N/A" for the target temperatures.
* ~~Add the possibility to perform an MQTT query request from the CLI. This is not really related to the above items, it was just considered for further enhancing the information displayed on the web interface, but this has not happened yet.~~  \
  -> will be part of another PR.

I tested it with my M5C using Firefox for Android and the desktop version of Firefox.

In a future step I would like to add "extrude", "retract", "pause/continue", "stop", so that we have the main things available you usually need during a print. And maybe a view-only mode would be good to have, too.