### PR TITLE
Web UI auth, Control tab, external webcam, and pre-print G36 hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__
 .DS_Store
 /settings.json
 .idea/
+.venv/
+ankerctl.log

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Order of Operations for Success:
 
 Follow the instructions for a [git install](documentation/install-from-git.md) (recommended), or [docker install](documentation/install-from-docker.md).
 
+For the Mac mini deployment used with OrcaSlicer, Tailscale, and the iPad
+WebRTC camera, see the [local macOS printer service runbook](documentation/local-macos-service.md).
+
 ## Importing configuration
 
 1. Import your AnkerMake account data by opening a terminal window in the folder you placed ankerctl in and running the following command:
@@ -132,6 +135,9 @@ Follow the instructions for a [git install](documentation/install-from-git.md) (
  > **Important**
  > If your `login.json` file was not automatically found, you’ll be prompted to upload your `login.json` file and the given the default path it should be found in your corresponding Operating System. 
    Once the `login.json` has been uploaded, the page will refresh and the web interface is usable.
+
+ > **Optional**
+ > Set `ANKERCTL_TOKEN` before starting the webserver to require a shared login token for the human web UI. The OctoPrint-compatible slicer endpoints (`/api/version` and `/api/files/local`) stay reachable without the token so Orca/PrusaSlicer "Send and Print" continues to work.
 
 ### Printing Directly from PrusaSlicer
 

--- a/cli/config.py
+++ b/cli/config.py
@@ -163,6 +163,10 @@ def import_config_from_server(config, login_data, insecure):
 
     # prepare to rescue any printer IP addresses already configured
     printer_ips = get_printer_ips(config)
+    webcam_url = get_webcam_url(config)
+
+    if webcam_url:
+        cfg.webcam_url = webcam_url
 
     # save config to json file named `ankerctl/default.json`
     config.save("default", cfg)
@@ -180,6 +184,14 @@ def get_printer_ips(config):
         printer_ips = {}
 
     return printer_ips
+
+
+def get_webcam_url(config):
+    try:
+        with config.open() as cfg:
+            return cfg.webcam_url
+    except KeyError:
+        return ""
 
 
 def update_empty_printer_ips(config, printer_ips):
@@ -225,11 +237,15 @@ def update_printer_ip_addresses(config, printer_ips: list) -> list:
 def attempt_config_upgrade(config, profile, insecure):
     path = config.config_path("default")
     data = json.load(path.open())
+    webcam_url = data.get("webcam_url", "")
     cfg = load_config_from_api(
         data["account"]["auth_token"],
         data["account"]["region"],
         insecure
     )
+
+    if webcam_url:
+        cfg.webcam_url = webcam_url
 
     # save config to json file named `ankerctl/default.json`
     config.save("default", cfg)

--- a/cli/model.py
+++ b/cli/model.py
@@ -77,6 +77,7 @@ class Account(Serialize):
 class Config(Serialize):
     account: Account
     printers: list[Printer]
+    webcam_url: str=""
 
     def __bool__(self):
         return bool(self.account)

--- a/documentation/local-macos-service.md
+++ b/documentation/local-macos-service.md
@@ -1,0 +1,750 @@
+# Local macOS Printer Service Runbook
+
+This document describes the AnkerMake M5C service installed on Gary's Mac
+mini, including the local `ankerctl` modifications, OrcaSlicer integration,
+Tailscale access, iPad camera relay, routine operations, troubleshooting, and
+recovery.
+
+The paths and network names below describe the installation as of
+2026-07-06. Credentials are intentionally omitted.
+
+## Safety and security
+
+- Never place account tokens, MQTT credentials, the web access token, Flask
+  secret key, or TLS private keys in source control or documentation.
+- The web UI is protected by `ANKERCTL_TOKEN`, but the OctoPrint-compatible
+  slicer endpoints remain unauthenticated so OrcaSlicer can upload jobs.
+- `ankerctl` listens on `0.0.0.0:4470`. Any device that can reach that port
+  can call the exempt upload endpoint and start a print. Restrict access with
+  the macOS firewall, network segmentation, or Tailscale ACLs.
+- MediaMTX listens on all interfaces. Treat its publisher URL as a control
+  endpoint: anyone who can reach it can replace the `ipadcam` stream.
+- Do not enable the experimental `G36` pre-print hook. See
+  [Disabled G36 experiment](#disabled-g36-experiment).
+- Supervise the first print after changing G-code, firmware, printer profiles,
+  upload logic, or network routing.
+
+## Architecture
+
+```text
+OrcaSlicer
+    |
+    | OctoPrint-compatible HTTP upload
+    v
+ankerctl on 0.0.0.0:4470
+    |                         |
+    | PPPP file transfer      | Anker cloud MQTT
+    v                         v
+AnkerMake M5C <--------- telemetry and controls
+
+iPad Safari camera
+    |
+    | Tailscale + encrypted WebRTC publish
+    v
+MediaMTX on :8889 / UDP :8189
+    |
+    | WebRTC viewer
+    v
+ankerctl embedded camera frame / remote browser
+```
+
+`ankerctl` uses MQTT for status and interactive controls. Print files are sent
+to the printer over PPPP. It does not retain a permanent copy of an uploaded
+G-code file.
+
+## Component inventory
+
+| Component | Location | Purpose |
+| --- | --- | --- |
+| `ankerctl` repository | `/Users/gary/ankermake-m5-protocol` | Printer service, web UI, MQTT and PPPP implementation |
+| Python environment | `/Users/gary/ankermake-m5-protocol/.venv` | Runtime dependencies |
+| Account/printer config | `/Users/gary/Library/Application Support/ankerctl/default.json` | Anker account, printer credentials, cached printer IP and webcam URL |
+| `ankerctl` LaunchAgent | `/Users/gary/Library/LaunchAgents/com.ankerctl.webserver.plist` | Starts the web service at login |
+| `ankerctl` log | `/Users/gary/ankermake-m5-protocol/ankerctl.log` | Web, MQTT, PPPP and upload events |
+| MediaMTX directory | `/Users/gary/mediamtx` | WebRTC relay, certificates and logs |
+| MediaMTX config | `/Users/gary/mediamtx/mediamtx.yml` | WebRTC listener and `ipadcam` path |
+| MediaMTX LaunchAgent | `/Users/gary/Library/LaunchAgents/com.mediamtx.webrtc.plist` | Starts the camera relay at login |
+| MediaMTX log | `/Users/gary/mediamtx/mediamtx.log` | Publisher, viewer and packet-loss events |
+| Orca M5C preset | `/Users/gary/Library/Application Support/OrcaSlicer/user/default/machine/Anker M5C.json` | Printer host and start G-code |
+
+Snapshot versions:
+
+- `ankerctl` base commit: `88131a5`, plus local uncommitted modifications.
+- Python: 3.12.13.
+- OrcaSlicer: 2.4.1.
+- MediaMTX: 1.19.2.
+- Tailscale CLI: 1.96.4. The system extension was observed at 1.98.5; align
+  these versions during the next Tailscale upgrade.
+- Printer firmware observed through MQTT: V3.1.56.
+
+## Network endpoints
+
+| Endpoint | Use |
+| --- | --- |
+| `http://127.0.0.1:4470` | Local `ankerctl` web UI and Orca upload host |
+| `http://192.168.68.55:4470` | Mac LAN web UI |
+| `https://garys-mac-mini.tail55ce6a.ts.net:8889/ipadcam/publish` | iPad camera publisher |
+| `https://garys-mac-mini.tail55ce6a.ts.net:8889/ipadcam` | Camera viewer |
+| `100.115.64.31` | Mac Tailscale IPv4 address at time of documentation |
+| `192.168.68.57` | Printer LAN address at time of documentation |
+
+Relevant listeners:
+
+| Port | Protocol | Process | Purpose |
+| --- | --- | --- | --- |
+| 4470 | TCP | Python / `ankerctl` | Web UI, API and WebSockets |
+| 8889 | TCP | MediaMTX | HTTPS WebRTC signaling and viewer/publisher pages |
+| 8189 | UDP | MediaMTX | WebRTC media |
+| 8892 | TCP/UDP | MediaMTX | Additional MediaMTX listener observed at runtime; not explicitly configured in the current YAML |
+
+Tailscale Serve also has unrelated proxies on ports 9119 and 9120. They are
+not part of this printer stack.
+
+## Initial installation
+
+### Repository and virtual environment
+
+```sh
+cd /Users/gary
+git clone https://github.com/Ankermgmt/ankermake-m5-protocol.git
+cd ankermake-m5-protocol
+
+python3 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+```
+
+Import the Anker/eufyMake login configuration:
+
+```sh
+cd /Users/gary/ankermake-m5-protocol
+.venv/bin/python ankerctl.py config import
+.venv/bin/python ankerctl.py config show
+```
+
+The imported configuration is sensitive. Back it up securely and never
+commit it.
+
+### Web service LaunchAgent
+
+The installed LaunchAgent runs:
+
+```text
+/Users/gary/ankermake-m5-protocol/.venv/bin/python
+/Users/gary/ankermake-m5-protocol/ankerctl.py
+webserver run --host 0.0.0.0
+```
+
+It uses:
+
+```text
+Label:             com.ankerctl.webserver
+WorkingDirectory:  /Users/gary/ankermake-m5-protocol
+RunAtLoad:         true
+KeepAlive:         true
+Log:               /Users/gary/ankermake-m5-protocol/ankerctl.log
+```
+
+Environment variables:
+
+| Variable | Purpose | Current policy |
+| --- | --- | --- |
+| `ANKERCTL_TOKEN` | Shared web UI login token | Required; value kept only in the plist |
+| `ANKERCTL_SECRET_KEY` | Stable Flask session signing key | Required; random secret kept only in the plist |
+| `ANKERCTL_PREPRINT_G36` | Experimental pre-upload preparation hook | Must remain `false` |
+| `ANKERCTL_PREPRINT_COMMAND_TIMEOUT` | Experimental hook timeout | Present but unused while hook is disabled |
+| `ANKERCTL_WEBCAM_URL` | Optional environment-level webcam URL | Not required when URL is saved in `default.json` |
+
+Generate new secrets rather than reusing documented examples:
+
+```sh
+openssl rand -base64 32
+openssl rand -base64 24
+```
+
+Load or reload the service:
+
+```sh
+plist="$HOME/Library/LaunchAgents/com.ankerctl.webserver.plist"
+plutil -lint "$plist"
+launchctl unload "$plist" 2>/dev/null || true
+launchctl load -w "$plist"
+```
+
+The older `launchctl load/unload` commands are used here because `bootstrap`
+returned an input/output error for this LaunchAgent on this Mac.
+
+## Routine service operations
+
+### Check service status
+
+```sh
+launchctl print "gui/$(id -u)/com.ankerctl.webserver" |
+  grep -E 'state =|pid =|job state'
+
+lsof -nP -iTCP:4470 -sTCP:LISTEN
+curl -I http://127.0.0.1:4470/
+```
+
+An unauthenticated `curl` returning HTTP 302 to `/login` is healthy when the
+access token is enabled.
+
+### Follow logs
+
+```sh
+tail -f /Users/gary/ankermake-m5-protocol/ankerctl.log
+```
+
+Useful filters:
+
+```sh
+grep -E 'Going to upload|File upload complete|Successfully sent print job' \
+  /Users/gary/ankermake-m5-protocol/ankerctl.log
+
+grep -Ei 'error|failed|timeout|connection lost' \
+  /Users/gary/ankermake-m5-protocol/ankerctl.log
+```
+
+### Restart only `ankerctl`
+
+```sh
+plist="$HOME/Library/LaunchAgents/com.ankerctl.webserver.plist"
+launchctl unload "$plist"
+launchctl load -w "$plist"
+```
+
+Restarting `ankerctl` does not restart the printer or MediaMTX.
+
+### Verify printer reachability
+
+```sh
+ping -c 2 192.168.68.57
+
+cd /Users/gary/ankermake-m5-protocol
+.venv/bin/python ankerctl.py pppp lan-search
+```
+
+The printer may not answer immediately after a power cycle. Wait until PPPP
+reaches `Running` before uploading.
+
+## Web UI and authentication
+
+The local web UI adds the following features to upstream `ankerctl`:
+
+- Shared-token login.
+- Authenticated MQTT, video, PPPP-state and control WebSockets.
+- External webcam URL configuration.
+- Embedded WebRTC camera viewer.
+- Control tab showing state, progress, temperatures, speed and layer.
+- Object preview image when supplied by printer telemetry.
+- Fan, jog, home, temperature and raw G-code controls.
+
+Authentication behavior:
+
+- `/login` accepts `ANKERCTL_TOKEN` and creates a Flask session.
+- `ANKERCTL_SECRET_KEY` keeps sessions valid across restarts.
+- `/api/version`, `/api/files/local`, `/login`, and static assets are exempt.
+- WebSocket handshakes reject unauthenticated clients with HTTP 401.
+
+The upload exemption is required by the current Orca integration, but it is
+also the main network security risk.
+
+### Control tab warning
+
+Raw G-code, fan, jog, home and temperature controls use the known
+`GCODE_COMMAND` MQTT primitive.
+
+The pause, resume and stop button values are best guesses and have not been
+validated against this M5C firmware. Do not rely on those buttons for safety.
+Use the printer/app controls or physical power switch when necessary.
+
+## OrcaSlicer configuration
+
+Configure the printer connection as an OctoPrint-compatible host:
+
+```text
+Host: http://127.0.0.1:4470
+API key: not required
+Operation: Send and Print
+```
+
+The saved user preset is:
+
+```text
+/Users/gary/Library/Application Support/OrcaSlicer/user/default/machine/Anker M5C.json
+```
+
+The required machine start G-code is:
+
+```gcode
+M4899 T3 ; Enable v3 jerk and S-curve acceleration
+M104 S150 ; Set hotend temp to 150 degrees to prevent ooze
+M190 S{first_layer_bed_temperature[0]} ; set and wait for bed temp to stabilize
+M109 S{first_layer_temperature[0]} ; set final nozzle temp to stabilize
+G28 ;Home
+;LAYER_COUNT:{total_layer_count}
+```
+
+Do not add `G36`, `M420 S1`, or the experimental pre-print block. The original
+`G28` block is the known-good configuration.
+
+After changing machine G-code, reslice the model. A previously generated
+G-code file keeps the old commands.
+
+### Expected print flow
+
+1. Orca slices the model.
+2. Orca posts the generated file to `/api/files/local`.
+3. `ankerctl` reads the file and opens a PPPP file-transfer session.
+4. The file is transferred to the M5C.
+5. The file-transfer end message asks the printer to start the job.
+6. MQTT telemetry reports job name, progress, remaining time, temperatures,
+   speed, and layer.
+
+Successful log sequence:
+
+```text
+Going to upload ... bytes as 'name.gcode'
+File upload complete. Requesting print start of job.
+Successfully sent print job
+```
+
+Each 32 KiB PPPP data block has a 15-second acknowledgement timeout. If PPPP
+drops during a large upload, the request now fails instead of holding the
+file-transfer service indefinitely. Interrupted uploads cannot resume and must
+be resent from Orca after PPPP reconnects.
+
+The service does not archive the uploaded G-code. Orca may keep a temporary
+copy below `/private/var/folders/.../orcaslicer_model/...`, but that path is
+ephemeral and may represent the currently loaded Orca plate rather than a job
+started from the phone app.
+
+## Account and printer configuration
+
+The live config is:
+
+```text
+/Users/gary/Library/Application Support/ankerctl/default.json
+```
+
+It contains:
+
+- Anker account identifiers and authentication tokens.
+- MQTT credentials and encryption material.
+- Printer identifiers and PPPP credentials.
+- Cached printer LAN address.
+- Optional external webcam URL.
+
+Safe summary command:
+
+```sh
+cd /Users/gary/ankermake-m5-protocol
+.venv/bin/python ankerctl.py config show
+```
+
+Do not paste the full JSON into chat, tickets, logs, or source control.
+
+The local changes preserve `webcam_url` when account configuration is
+re-imported or upgraded.
+
+## iPad camera and MediaMTX
+
+### Service configuration
+
+MediaMTX runs from:
+
+```text
+/Users/gary/mediamtx/mediamtx
+/Users/gary/mediamtx/mediamtx.yml
+```
+
+The current configuration enables only encrypted WebRTC:
+
+```yaml
+logLevel: info
+api: no
+metrics: no
+rtsp: no
+rtmp: no
+hls: no
+srt: no
+
+webrtc: yes
+webrtcAddress: :8889
+webrtcEncryption: yes
+webrtcServerCert: /Users/gary/mediamtx/tls.crt
+webrtcServerKey: /Users/gary/mediamtx/tls.key
+webrtcLocalUDPAddress: :8189
+webrtcIPsFromInterfaces: no
+webrtcAdditionalHosts:
+  - 100.115.64.31
+  - garys-mac-mini.tail55ce6a.ts.net
+
+paths:
+  ipadcam:
+```
+
+The certificate is issued for:
+
+```text
+garys-mac-mini.tail55ce6a.ts.net
+```
+
+Use the DNS hostname, not the Tailscale IP, when certificate validation
+matters.
+
+### Start and stop MediaMTX
+
+```sh
+plist="$HOME/Library/LaunchAgents/com.mediamtx.webrtc.plist"
+plutil -lint "$plist"
+launchctl unload "$plist" 2>/dev/null || true
+launchctl load -w "$plist"
+```
+
+Status and logs:
+
+```sh
+launchctl print "gui/$(id -u)/com.mediamtx.webrtc"
+tail -f /Users/gary/mediamtx/mediamtx.log
+lsof -nP -iTCP:8889 -sTCP:LISTEN
+lsof -nP -iUDP:8189
+```
+
+### Connect the iPad camera
+
+1. Open Tailscale on the iPad.
+2. Confirm the iPad shows online in the same tailnet.
+3. Open Safari to:
+
+   ```text
+   https://garys-mac-mini.tail55ce6a.ts.net:8889/ipadcam/publish
+   ```
+
+4. Allow camera and microphone access.
+5. Start publishing.
+6. Keep Safari in the foreground and prevent the iPad from sleeping.
+
+Viewer:
+
+```text
+https://garys-mac-mini.tail55ce6a.ts.net:8889/ipadcam
+```
+
+The viewer URL can be saved under **Setup → External Webcam URL** in the
+`ankerctl` UI. It is stored as `webcam_url` in `default.json`.
+
+### Camera diagnostics
+
+Check tailnet devices:
+
+```sh
+tailscale status
+tailscale ping 100.78.175.76
+```
+
+Check publisher status through logs:
+
+```sh
+grep -E "ipadcam|is publishing|stream is available|no stream is available" \
+  /Users/gary/mediamtx/mediamtx.log | tail -n 50
+```
+
+Healthy publisher messages:
+
+```text
+[path ipadcam] stream is available and online
+[WebRTC] ... is publishing to path 'ipadcam'
+```
+
+No publisher:
+
+```text
+no stream is available on path 'ipadcam'
+```
+
+Packet-loss symptoms:
+
+```text
+RTP packets lost
+received a non-starting fragment
+```
+
+For persistent packet loss:
+
+1. Keep the iPad awake and Safari foregrounded.
+2. Confirm both devices have stable Wi-Fi.
+3. Disable Low Power Mode on the iPad.
+4. Reload the publisher page.
+5. Restart MediaMTX only if a fresh publisher still fails.
+
+## Tailscale operations
+
+Mac identity at time of documentation:
+
+```text
+MagicDNS: garys-mac-mini.tail55ce6a.ts.net
+IPv4:     100.115.64.31
+```
+
+Useful commands:
+
+```sh
+tailscale status
+tailscale status --json | jq .
+tailscale ping <peer-name-or-IP>
+tailscale serve status
+```
+
+An iOS peer can appear offline while the app/VPN is suspended. Opening the
+Tailscale app on the iPad usually reactivates it.
+
+The Tailscale CLI and system-extension versions currently differ. This is not
+the cause of the printer issues documented here, but they should be updated
+together.
+
+## Troubleshooting
+
+### Orca says sent, but no print starts
+
+1. Confirm the pre-print hook is disabled:
+
+   ```sh
+   launchctl print "gui/$(id -u)/com.ankerctl.webserver" |
+     grep ANKERCTL_PREPRINT_G36
+   ```
+
+   Required value:
+
+   ```text
+   ANKERCTL_PREPRINT_G36 => false
+   ```
+
+2. Confirm the G-code contains the original `G28` block.
+3. Check the three expected upload log messages.
+4. Check PPPP state through `/api/ankerctl/status`.
+5. Power-cycle the printer if it does not reconnect after a failed command.
+6. Resend only after PPPP is `Running`.
+
+### PPPP is `Starting` after a printer reboot
+
+The printer may need 30–60 seconds to rejoin Wi-Fi.
+
+```sh
+ping -c 2 192.168.68.57
+tail -f /Users/gary/ankermake-m5-protocol/ankerctl.log
+```
+
+Look for:
+
+```text
+Successfully connected to printer ... over pppp
+Established pppp connection
+PPPP connection established
+```
+
+### A large upload stops partway through
+
+Look for an upload that reaches `Sending file contents` without reaching
+`File upload complete`, followed by `PPPP connection lost`.
+
+The current service aborts a transfer when a 32 KiB block is not acknowledged
+within 15 seconds. Wait for PPPP to return to `Running`, then resend the
+complete file. Partial transfers are not resumable.
+
+### MQTT works but PPPP does not
+
+MQTT is cloud-mediated; PPPP file transfer may use the printer's LAN address.
+Confirm the Mac and printer are on reachable networks and the cached printer
+IP is current.
+
+Run:
+
+```sh
+.venv/bin/python ankerctl.py pppp lan-search
+```
+
+Then update/re-import configuration if the cached address is stale.
+
+### Web UI redirects to login
+
+This is expected when `ANKERCTL_TOKEN` is set. Use the configured access
+token. Do not remove authentication merely to fix slicer uploads; the slicer
+endpoints are already exempt.
+
+### Orca cannot test the host
+
+```sh
+curl http://127.0.0.1:4470/api/version
+lsof -nP -iTCP:4470 -sTCP:LISTEN
+```
+
+Use `127.0.0.1:4470` when Orca runs on this Mac. Use the Mac's LAN or
+Tailscale address only when Orca runs on another machine.
+
+### Printer command queue is stuck
+
+Symptoms:
+
+- Temperatures remain targeted but no motion occurs.
+- Normal `M104 S0` / `M140 S0` commands do not change reported targets.
+- MQTT returns stale or unrelated acknowledgements.
+
+Recovery:
+
+1. Do not send another print.
+2. Disable the experimental hook if enabled.
+3. Use the printer's physical power switch.
+4. Leave it off for at least 10 seconds.
+5. Power it on.
+6. Verify both heater targets report 0°C.
+7. Wait for PPPP to return to `Running`.
+8. Resume only with the original Orca start G-code.
+
+Do not trust an MQTT `ok` response as proof that a queued emergency command
+executed. Verify the reported target temperatures.
+
+## Disabled G36 experiment
+
+The official eufyMake M5C Marlin source contains `G36` and internal wiping,
+alignment and homing routines. That does not mean production firmware accepts
+`G36` in every transport.
+
+Observed behavior on firmware V3.1.56:
+
+1. Embedding `G36` in uploaded G-code caused the job not to start.
+2. Sending `G36` through MQTT after preheating was accepted but did not produce
+   reliable motion/completion behavior.
+3. The command queue became wedged.
+4. Heater-off commands returned misleading acknowledgements while targets
+   remained active.
+5. A physical printer power cycle was required.
+
+The local code contains an opt-in pre-print implementation in `web/util.py`
+for research history, but the LaunchAgent sets:
+
+```text
+ANKERCTL_PREPRINT_G36=false
+```
+
+This must remain disabled. Do not re-enable it without a dedicated test
+environment, serial-console visibility, and a confirmed production-firmware
+command contract.
+
+The supported configuration is the original `G28` start sequence.
+
+## Tests and development checks
+
+Run the focused local tests:
+
+```sh
+cd /Users/gary/ankermake-m5-protocol
+.venv/bin/python -m unittest discover -s tests -v
+.venv/bin/python -m compileall -q web tests
+git diff --check
+```
+
+Before editing:
+
+```sh
+git status --short
+git diff
+```
+
+This checkout contains local changes. Do not reset, overwrite, or discard
+unrelated modifications when upgrading.
+
+## Backup and restore
+
+Back up these items securely:
+
+```text
+/Users/gary/ankermake-m5-protocol
+/Users/gary/Library/Application Support/ankerctl/default.json
+/Users/gary/Library/LaunchAgents/com.ankerctl.webserver.plist
+/Users/gary/mediamtx/mediamtx.yml
+/Users/gary/mediamtx/tls.crt
+/Users/gary/mediamtx/tls.key
+/Users/gary/Library/LaunchAgents/com.mediamtx.webrtc.plist
+/Users/gary/Library/Application Support/OrcaSlicer/user/default/machine/Anker M5C.json
+```
+
+The backup contains credentials and private keys. Encrypt it and restrict file
+permissions.
+
+Example permission audit:
+
+```sh
+ls -l \
+  "$HOME/Library/Application Support/ankerctl/default.json" \
+  "$HOME/Library/LaunchAgents/com.ankerctl.webserver.plist" \
+  /Users/gary/mediamtx/tls.key
+```
+
+After restore:
+
+1. Recreate or restore `.venv`.
+2. Validate both plists with `plutil -lint`.
+3. Load both LaunchAgents.
+4. Confirm Tailscale is online.
+5. Confirm port 4470 and MediaMTX ports are listening.
+6. Confirm printer PPPP and MQTT services.
+7. Test the camera publisher/viewer.
+8. Run a small supervised test print.
+
+## Upgrade procedure
+
+1. Stop printing and ensure both heater targets are zero.
+2. Back up the repository, config, plists and MediaMTX keys.
+3. Review local changes:
+
+   ```sh
+   git status --short
+   git diff
+   ```
+
+4. Fetch upstream without discarding local work.
+5. Reconcile conflicts deliberately.
+6. Update the virtual environment:
+
+   ```sh
+   .venv/bin/pip install -r requirements.txt
+   ```
+
+7. Run tests and syntax checks.
+8. Restart `ankerctl`.
+9. Verify login, MQTT, PPPP, Orca upload and camera relay.
+10. Run a small supervised print.
+
+Never use `git reset --hard` or replace the checkout without first preserving
+the local changes.
+
+## External source references
+
+- Community protocol project:
+  <https://github.com/Ankermgmt/ankermake-m5-protocol>
+- Official M5C firmware source:
+  <https://github.com/eufymake/eufyMake-Marlin-M5C>
+- Official eufyMake PrusaSlicer source:
+  <https://github.com/eufymake/eufyMake-PrusaSlicer-Release>
+- MediaMTX:
+  <https://github.com/bluenviron/mediamtx>
+- Tailscale:
+  <https://tailscale.com/kb>
+
+## Daily checklist
+
+Before printing:
+
+- Printer is online and reachable.
+- PPPP and MQTT services are `Running`.
+- Orca start G-code contains `G28`, not `G36`.
+- `ANKERCTL_PREPRINT_G36` is `false`.
+- Build plate and toolhead path are clear.
+- Camera publisher is online if remote monitoring is required.
+
+After printing:
+
+- Confirm the job completed normally.
+- Confirm heater targets return to zero.
+- Review logs if PPPP or camera connections dropped.
+- Keep the iPad powered if it remains the monitoring camera.

--- a/static/ankersrv.css
+++ b/static/ankersrv.css
@@ -85,6 +85,15 @@ code {
 
 /* Layout */
 
+header .nav {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+}
+
+header .nav-item {
+    flex: 0 0 auto;
+}
+
 #printProgress {
     height: 40px;
 }
@@ -136,4 +145,33 @@ body.fullscreen-emulate-active {
 
 .fullscreen-emulate-d-none-active {
     display: none;
+}
+
+.control-panel .card {
+    height: 100%;
+}
+
+.control-stat-label {
+    color: var(--bs-secondary-color);
+    font-size: 0.875rem;
+}
+
+.control-stat-value {
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+
+.control-webcam {
+    aspect-ratio: 4 / 3;
+    object-fit: contain;
+}
+
+@media (max-width: 767.98px) {
+    .control-panel {
+        padding-bottom: 1rem;
+    }
+
+    .control-stat-value {
+        font-size: 1rem;
+    }
 }

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -181,6 +181,31 @@ $(function () {
         return `X${speed / 50}`;
     }
 
+    function setText(selectors, value) {
+        selectors.forEach(function (selector) {
+            $(selector).text(value);
+        });
+    }
+
+    function setDisabled(selectors, disabled) {
+        selectors.forEach(function (selector) {
+            const elem = $(selector).get(0);
+            if (elem) {
+                elem.disabled = disabled;
+            }
+        });
+    }
+
+    function getPrinterState(data) {
+        const keys = ["state", "status", "print_state", "printState", "machineStatus", "currentStatus"];
+        for (const key of keys) {
+            if (Object.prototype.hasOwnProperty.call(data, key)) {
+                return `${data[key]}`;
+            }
+        }
+        return null;
+    }
+
     /**
      * Updates the country code <select> element
      */
@@ -340,13 +365,15 @@ $(function () {
         badge: "#badge-mqtt",
 
         opened: function (event) {
-            ["#set-nozzle-temp", "#set-bed-temp"].forEach(function (elem_id) {
-                $(elem_id)[0].disabled = false;
-            });
+            setDisabled(["#set-nozzle-temp", "#set-bed-temp"], false);
         },
 
         message: function (ev) {
             const data = JSON.parse(ev.data);
+            const state = getPrinterState(data);
+            if (state !== null) {
+                setText(["#control-printer-state"], state);
+            }
             if (data.commandType == 1001) {
                 // Returns Print Details
                 $("#print-name").text(data.name);
@@ -355,35 +382,49 @@ $(function () {
                 const progress = getPercentage(data.progress);
                 $("#progressbar").attr("aria-valuenow", progress);
                 $("#progressbar").attr("style", `width: ${progress}%`);
-                $("#progress").text(`${progress}%`);
+                setText(["#progress", "#control-progress"], `${progress}%`);
+                // Control tab: object preview (printer-provided image URL) + overlay
+                if (data.img) {
+                    if ($("#control-preview-img").attr("src") !== data.img) {
+                        $("#control-preview-img").attr("src", data.img);
+                    }
+                    $("#control-preview-name").text(data.name || "");
+                    $("#control-preview-wrap").show();
+                }
+                $("#control-preview-bar")
+                    .text(`${progress}%`)
+                    .attr("aria-valuenow", progress)
+                    .attr("style", `width: ${progress}%`);
             } else if (data.commandType == 1003) {
                 // Returns Nozzle Temp
                 const current = getTemp(data.currentTemp);
-                $("#nozzle-temp").text(`${current}°C`);
+                setText(["#nozzle-temp", "#control-nozzle-current"], `${current}°C`);
                 if (Object.prototype.hasOwnProperty.call(data, "targetTemp")) {
                     const target = getTemp(data.targetTemp);
                     if (!isNaN(target)) {
-                        $("#set-nozzle-temp").text(`${target}°C`);
+                        setText(["#set-nozzle-temp", "#control-nozzle-target"], `${target}°C`);
+                        $("#control-nozzle-input").val(target);
                     }
                 }
             } else if (data.commandType == 1004) {
                 // Returns Bed Temp
                 const current = getTemp(data.currentTemp);
-                $("#bed-temp").text(`${current}°C`);
+                setText(["#bed-temp", "#control-bed-current"], `${current}°C`);
                 if (Object.prototype.hasOwnProperty.call(data, "targetTemp")) {
                     const target = getTemp(data.targetTemp);
                     if (!isNaN(target)) {
-                        $("#set-bed-temp").text(`${target}°C`);
+                        setText(["#set-bed-temp", "#control-bed-target"], `${target}°C`);
+                        $("#control-bed-input").val(target);
                     }
                 }
             } else if (data.commandType == 1006) {
                 // Returns Print Speed
                 const X = getSpeedFactor(data.value);
-                $("#print-speed").text(`${data.value}mm/s ${X}`);
+                setText(["#print-speed", "#control-print-speed"], `${data.value}mm/s ${X}`);
             } else if (data.commandType == 1052) {
                 // Returns Layer Info
                 const layer = `${data.real_print_layer} / ${data.total_layer}`;
-                $("#print-layer").text(layer);
+                setText(["#print-layer", "#control-layer"], layer);
             } else {
                 console.log("Unhandled mqtt message:", data);
             }
@@ -395,17 +436,15 @@ $(function () {
             $("#time-remain").text("00:00:00");
             $("#progressbar").attr("aria-valuenow", 0);
             $("#progressbar").attr("style", "width: 0%");
-            $("#progress").text("0%");
-            $("#nozzle-temp").text("0°C");
-            $("#set-nozzle-temp").text("0°C");
-            $("#bed-temp").text("0°C");
-            $("#set-bed-temp").text("0°C");
-            $("#print-speed").text("0mm/s");
-            $("#print-layer").text("0 / 0");
-
-            ["#set-nozzle-temp", "#set-bed-temp"].forEach(function (elem_id) {
-                $(elem_id).get(0).disabled = true;
-            });
+            setText(["#progress", "#control-progress"], "0%");
+            setText(["#nozzle-temp", "#control-nozzle-current"], "0°C");
+            setText(["#set-nozzle-temp", "#control-nozzle-target"], "0°C");
+            setText(["#bed-temp", "#control-bed-current"], "0°C");
+            setText(["#set-bed-temp", "#control-bed-target"], "0°C");
+            setText(["#print-speed", "#control-print-speed"], "0mm/s");
+            setText(["#print-layer", "#control-layer"], "0 / 0");
+            setText(["#control-printer-state"], "Disconnected");
+            setDisabled(["#set-nozzle-temp", "#set-bed-temp"], true);
         },
     });
 
@@ -453,8 +492,29 @@ $(function () {
 
     sockets.ctrl = new AutoWebSocket({
         name: "Control socket",
-        url: `${location.protocol.replace('http','ws')}${location.host}/ws/ctrl`,
+        url: `${location.protocol.replace('http','ws')}//${location.host}/ws/ctrl`,
         badge: "#badge-ctrl",
+
+        opened: function () {
+            $(".control-command").prop("disabled", false);
+        },
+
+        message: function (event) {
+            const data = JSON.parse(event.data);
+            if (Object.prototype.hasOwnProperty.call(data, "mqttReply")) {
+                if (data.mqttReply && Object.prototype.hasOwnProperty.call(data.mqttReply, "resData")) {
+                    appendGcodeLog(`< ${data.mqttReply.resData}`);
+                } else if (data.mqttReply) {
+                    appendGcodeLog(`< ${JSON.stringify(data.mqttReply)}`);
+                } else {
+                    appendGcodeLog("< No response");
+                }
+            }
+        },
+
+        close: function () {
+            $(".control-command").prop("disabled", true);
+        },
     });
 
     sockets.pppp_state = new AutoWebSocket({
@@ -617,5 +677,122 @@ $(function () {
             sockets.ctrl.ws.send(JSON.stringify({ mqtt: message_data }));
         }
     }
+
+    /**
+     * Control tab
+     *
+     * Sends printer commands over the /ws/ctrl websocket. Movement, fan and
+     * temperature actions use raw GCode (GCODE_COMMAND), which is a well-known
+     * primitive. Pause/resume/stop use PRINT_CONTROL, whose value encoding is
+     * not yet confirmed (see TODO below).
+     */
+    function ctrlReady() {
+        return sockets.ctrl && sockets.ctrl.ws && sockets.ctrl.is_open;
+    }
+
+    function appendGcodeLog(line) {
+        const logElem = $("#gcode-log");
+        if (!logElem.length) {
+            return;
+        }
+        logElem.append(document.createTextNode(`${line}\n`));
+        logElem.get(0).scrollTop = logElem.get(0).scrollHeight;
+    }
+
+    function sendMqtt(message_data, awaitResponse = false) {
+        if (!ctrlReady()) {
+            flash_message("Control socket not connected", "warning");
+            return;
+        }
+        sockets.ctrl.ws.send(JSON.stringify({
+            mqtt: message_data,
+            awaitResponse: awaitResponse,
+        }));
+    }
+
+    function sendGcode(line, awaitResponse = false) {
+        sendMqtt({
+            commandType: MqttMsgType.ZZ_MQTT_CMD_GCODE_COMMAND,
+            cmdData: line,
+            cmdLen: line.length,
+        }, awaitResponse);
+        appendGcodeLog(`> ${line}`);
+    }
+
+    // Pause / Resume / Stop.
+    // TODO verify PRINT_CONTROL values (1=pause, 2=resume, 3=stop are best-guess
+    // and unconfirmed against the M5/M5C firmware).
+    $("#print-pause").on("click", function () {
+        sendMqtt({ commandType: MqttMsgType.ZZ_MQTT_CMD_PRINT_CONTROL, value: 1 });
+        return false;
+    });
+    $("#print-resume").on("click", function () {
+        sendMqtt({ commandType: MqttMsgType.ZZ_MQTT_CMD_PRINT_CONTROL, value: 2 });
+        return false;
+    });
+    $("#print-stop").on("click", function () {
+        if (window.confirm("Stop the current print?")) {
+            sendMqtt({ commandType: MqttMsgType.ZZ_MQTT_CMD_PRINT_CONTROL, value: 3 });
+        }
+        return false;
+    });
+
+    // Part fan (0-100% -> M106 S0-255, 0 -> M107)
+    $("#fan-slider").on("input", function () {
+        $("#fan-value").text(`${this.value}%`);
+    });
+    $("#fan-apply").on("click", function () {
+        const pct = parseInt($("#fan-slider").val());
+        if (pct <= 0) {
+            sendGcode("M107");
+        } else {
+            sendGcode(`M106 S${Math.round(pct * 255 / 100)}`);
+        }
+        return false;
+    });
+
+    // Jog + home (relative moves)
+    $(".jog-btn").on("click", function () {
+        const axis = $(this).data("axis");
+        const dir = parseInt($(this).data("dir"));
+        const step = parseFloat($("#jog-step").val()) * dir;
+        const feed = (axis === "Z") ? 600 : 3000;
+        sendGcode(`G91;G1 ${axis}${step} F${feed};G90`);
+        return false;
+    });
+    $("#jog-home").on("click", function () {
+        sendGcode("G28");
+        return false;
+    });
+
+    $("#control-nozzle-form").on("submit", function (event) {
+        event.preventDefault();
+        const target = parseInt($("#control-nozzle-input").val());
+        if (!isNaN(target)) {
+            sendGcode(`M104 S${target}`);
+        }
+        return false;
+    });
+
+    $("#control-bed-form").on("submit", function (event) {
+        event.preventDefault();
+        const target = parseInt($("#control-bed-input").val());
+        if (!isNaN(target)) {
+            sendGcode(`M140 S${target}`);
+        }
+        return false;
+    });
+
+    // GCode terminal
+    $("#gcode-form").on("submit", function (event) {
+        event.preventDefault();
+        const input = $("#gcode-input");
+        const line = input.val().trim();
+        if (line) {
+            sendGcode(line, true);
+            input.val("");
+        }
+        return false;
+    });
 
 });

--- a/static/index.html
+++ b/static/index.html
@@ -8,6 +8,7 @@
 {% block contents %}
     {% if configure %}
         {% include "tabs/home.html" %}
+        {% include "tabs/control.html" %}
         {% include "tabs/instructions.html" %}
         {% include "tabs/print.html" %}
     {% endif %}
@@ -19,6 +20,10 @@
     {% if configure %}
         {% call macro.menu_button(id="home-tab", target="home", active=configure) %}
             {{ macro.bi_icon("house", "Live") }}
+        {% endcall %}
+
+        {% call macro.menu_button(id="control-tab", target="control") %}
+            {{ macro.bi_icon("sliders", "Control") }}
         {% endcall %}
 
         {% call macro.menu_button(id="print-tab", target="print") %}

--- a/static/login.html
+++ b/static/login.html
@@ -1,0 +1,56 @@
+{% import "macro.html" as macro -%}
+<!DOCTYPE html>
+<html data-bs-theme="dark" lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta content="width=device-width, initial-scale=1" name="viewport" />
+        <title>ankerctl - Login</title>
+        <link rel="icon" href="{{ url_for('static', filename='img/logo.svg') }}">
+        {{ macro.static_css("vendor/bootstrap-5.3.0-alpha3-dist/css/bootstrap.min.css") }}
+        {{ macro.static_css("vendor/bootstrap-icons-1.10.5/font/bootstrap-icons.min.css") }}
+        {{ macro.static_css("ankersrv.css") }}
+    </head>
+    <body>
+        <div class="container" style="max-width: 24rem;">
+            <div class="text-center my-4">
+                <img src="{{ url_for('static', filename='img/logo.svg') }}" alt="logo" height="48">
+            </div>
+
+            <div class="container text-center" id="messages">
+                {% for category, message in get_flashed_messages(with_categories=true) %}
+                <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+                    <button type="button" class="btn-close btn-sm btn-close-white"
+                            data-bs-dismiss="alert" aria-label="Close"></button>
+                    {{ message }}
+                </div>
+                {% endfor %}
+            </div>
+
+            <div class="card">
+                <div class="card-header">Access token required</div>
+                <div class="card-body">
+                    <form method="post">
+                        <input type="hidden" name="next" value="{{ next_url }}" />
+                        <div class="input-group">
+                            <div class="input-group-text">
+                                {{ macro.bi_icon("key-fill") }}
+                            </div>
+                            <input
+                                type="password"
+                                name="token"
+                                class="form-control"
+                                placeholder="Token"
+                                autofocus
+                                required
+                            />
+                        </div>
+                        <button type="submit" class="btn btn-primary w-100 mt-3">
+                            {{ macro.bi_icon("box-arrow-in-right", "Log in") }}
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </div>
+        {{ macro.static_script("vendor/bootstrap-5.3.0-alpha3-dist/js/bootstrap.bundle.min.js") }}
+    </body>
+</html>

--- a/static/tabs/control.html
+++ b/static/tabs/control.html
@@ -1,0 +1,208 @@
+<div
+    class="tab-pane fade"
+    id="control"
+    role="tabpanel"
+    aria-labelledby="control-tab"
+>
+    <div class="container fullscreen-emulate control-panel">
+        <div class="row g-3">
+            <div class="col-12 col-xl-6" id="control-preview-wrap" style="display: none;">
+                <div class="card">
+                    <div class="card-header fs-6">Preview</div>
+                    <div class="card-body text-center">
+                        <img id="control-preview-img"
+                             class="d-block rounded-3 bg-body-tertiary mx-auto mb-2"
+                             style="max-height: 16rem; max-width: 100%;"
+                             alt="Print preview">
+                        <div id="control-preview-name" class="small text-truncate mb-1"></div>
+                        <div class="progress">
+                            <div id="control-preview-bar"
+                                 class="progress-bar progress-bar-striped progress-bar-animated"
+                                 role="progressbar" aria-valuemin="0" aria-valuemax="100"
+                                 aria-valuenow="0" style="width: 0%">0%</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header fs-6">Status</div>
+                    <div class="card-body">
+                        <div class="row g-3">
+                            <div class="col-6 col-lg-4">
+                                <div class="control-stat-label">Nozzle</div>
+                                <div class="control-stat-value">
+                                    <span id="control-nozzle-current">0°C</span>
+                                    <span class="text-body-secondary">/</span>
+                                    <span id="control-nozzle-target">0°C</span>
+                                </div>
+                            </div>
+                            <div class="col-6 col-lg-4">
+                                <div class="control-stat-label">Bed</div>
+                                <div class="control-stat-value">
+                                    <span id="control-bed-current">0°C</span>
+                                    <span class="text-body-secondary">/</span>
+                                    <span id="control-bed-target">0°C</span>
+                                </div>
+                            </div>
+                            <div class="col-6 col-lg-4">
+                                <div class="control-stat-label">Progress</div>
+                                <div class="control-stat-value" id="control-progress">0%</div>
+                            </div>
+                            <div class="col-6 col-lg-4">
+                                <div class="control-stat-label">Layer</div>
+                                <div class="control-stat-value" id="control-layer">0 / 0</div>
+                            </div>
+                            <div class="col-6 col-lg-4">
+                                <div class="control-stat-label">State</div>
+                                <div class="control-stat-value" id="control-printer-state">Unknown</div>
+                            </div>
+                            <div class="col-6 col-lg-4">
+                                <div class="control-stat-label">Speed</div>
+                                <div class="control-stat-value" id="control-print-speed">0mm/s</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            {% if webcam_url %}
+            <div class="col-12 col-xl-6">
+                <div class="card">
+                    <div class="card-header fs-6">Webcam</div>
+                    <div class="card-body">
+                        <iframe src="{{ webcam_url }}"
+                                class="w-100 d-block rounded-3 bg-body-tertiary control-webcam"
+                                style="border: 0; aspect-ratio: 16 / 9;"
+                                allow="autoplay; fullscreen"
+                                title="Webcam stream" id="webcam-frame"></iframe>
+                    </div>
+                </div>
+            </div>
+            {% endif %}
+
+            <div class="col-12 col-xl-6">
+                <div class="card mb-3">
+                    <div class="card-header fs-6">Print</div>
+                    <div class="card-body">
+                        <div class="row g-3">
+                            <div class="col-4">
+                                <button class="w-100 btn btn-secondary control-command" id="print-pause" type="button" disabled>
+                                    {{ macro.bi_icon("pause-fill", "Pause") }}
+                                </button>
+                            </div>
+                            <div class="col-4">
+                                <button class="w-100 btn btn-secondary control-command" id="print-resume" type="button" disabled>
+                                    {{ macro.bi_icon("play-fill", "Resume") }}
+                                </button>
+                            </div>
+                            <div class="col-4">
+                                <button class="w-100 btn btn-danger control-command" id="print-stop" type="button" disabled>
+                                    {{ macro.bi_icon("stop-fill", "Stop") }}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card mb-3">
+                    <div class="card-header fs-6">Temperatures</div>
+                    <div class="card-body">
+                        <form class="mb-3" id="control-nozzle-form">
+                            <label class="form-label" for="control-nozzle-input">Nozzle target</label>
+                            <div class="input-group">
+                                <input type="number" class="form-control" min="0" max="300" id="control-nozzle-input" value="0" />
+                                <span class="input-group-text">°C</span>
+                                <button class="btn btn-primary control-command" type="submit" disabled>Set</button>
+                            </div>
+                        </form>
+
+                        <form id="control-bed-form">
+                            <label class="form-label" for="control-bed-input">Bed target</label>
+                            <div class="input-group">
+                                <input type="number" class="form-control" min="0" max="120" id="control-bed-input" value="0" />
+                                <span class="input-group-text">°C</span>
+                                <button class="btn btn-primary control-command" type="submit" disabled>Set</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+
+                <div class="card mb-3">
+                    <div class="card-header fs-6">Part Fan</div>
+                    <div class="card-body">
+                        <div class="d-flex align-items-center gap-3">
+                            <input type="range" class="form-range" min="0" max="100" step="5"
+                                   value="0" id="fan-slider">
+                            <span id="fan-value" class="text-nowrap">0%</span>
+                        </div>
+                        <button class="btn btn-secondary w-100 mt-3 control-command" id="fan-apply" type="button" disabled>
+                            {{ macro.bi_icon("fan", "Set Fan") }}
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-12 col-xl-6">
+                <div class="card mb-3">
+                    <div class="card-header fs-6">Move</div>
+                    <div class="card-body">
+                        <div class="row g-2 mb-3">
+                            <div class="col-4">
+                                <label class="form-label small mb-1">Step (mm)</label>
+                                <select class="form-select" id="jog-step">
+                                    <option value="0.1">0.1</option>
+                                    <option value="1">1</option>
+                                    <option value="10" selected>10</option>
+                                    <option value="50">50</option>
+                                </select>
+                            </div>
+                            <div class="col-8 d-flex align-items-end">
+                                <button class="w-100 btn btn-secondary control-command" id="jog-home" type="button" disabled>
+                                    {{ macro.bi_icon("house-fill", "Home All") }}
+                                </button>
+                            </div>
+                        </div>
+                        <div class="row g-2">
+                            <div class="col-4">
+                                <button class="w-100 btn btn-secondary jog-btn control-command" data-axis="X" data-dir="-1" type="button" disabled>X-</button>
+                            </div>
+                            <div class="col-4">
+                                <button class="w-100 btn btn-secondary jog-btn control-command" data-axis="X" data-dir="1" type="button" disabled>X+</button>
+                            </div>
+                            <div class="col-4">
+                                <button class="w-100 btn btn-secondary jog-btn control-command" data-axis="Z" data-dir="1" type="button" disabled>Z+</button>
+                            </div>
+                            <div class="col-4">
+                                <button class="w-100 btn btn-secondary jog-btn control-command" data-axis="Y" data-dir="-1" type="button" disabled>Y-</button>
+                            </div>
+                            <div class="col-4">
+                                <button class="w-100 btn btn-secondary jog-btn control-command" data-axis="Y" data-dir="1" type="button" disabled>Y+</button>
+                            </div>
+                            <div class="col-4">
+                                <button class="w-100 btn btn-secondary jog-btn control-command" data-axis="Z" data-dir="-1" type="button" disabled>Z-</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-12 col-xl-6">
+                <div class="card">
+                    <div class="card-header fs-6">GCode Terminal</div>
+                    <div class="card-body">
+                        <form id="gcode-form">
+                            <div class="input-group mb-2">
+                                <input type="text" class="form-control font-monospace" id="gcode-input"
+                                       placeholder="e.g. M104 S200" autocomplete="off">
+                                <button class="btn btn-primary control-command" type="submit" disabled>Send</button>
+                            </div>
+                        </form>
+                        <pre id="gcode-log" class="bg-body-tertiary rounded-3 p-2 mb-0 small"
+                             style="height: 10rem; overflow-y: auto;"></pre>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/static/tabs/home.html
+++ b/static/tabs/home.html
@@ -23,6 +23,13 @@
                         {{ macro.bi_icon("fullscreen") }}
                     </button>
                 </div>
+                {% elif webcam_url %}
+                <!-- External webcam (e.g. MediaMTX WebRTC / MJPEG) -->
+                <iframe src="{{ webcam_url }}"
+                        class="w-100 d-block rounded-3 bg-body-tertiary"
+                        style="border: 0; aspect-ratio: 16 / 9;"
+                        allow="autoplay; fullscreen"
+                        title="Webcam stream" id="webcam-frame-live"></iframe>
                 {% else %}
                 <div class="card">
                     <div class="card-body text-center">

--- a/static/tabs/setup.html
+++ b/static/tabs/setup.html
@@ -156,6 +156,38 @@
                     </div>
                 </form>
 
+                <form
+                    action="{{ url_for('app_api_ankerctl_config_webcam') }}"
+                    method="POST"
+                    class="mb-3"
+                    id="config-webcam-form"
+                >
+                    <div class="card">
+                        <div class="card-header fs-4">
+                            External Webcam URL
+                        </div>
+                        <div class="card-body">
+                            <div class="input-group">
+                                <div class="input-group-text">URL</div>
+                                <input
+                                    class="form-control"
+                                    type="url"
+                                    id="webcamUrl"
+                                    name="webcam_url"
+                                    placeholder="http://camera.local:8080/video"
+                                    value="{{ webcam_url }}"
+                                />
+                                <button class="btn btn-secondary submit" type="submit">
+                                    {{ macro.bi_icon("camera-video", "Save") }}
+                                </button>
+                            </div>
+                        </div>
+                        <div class="card-footer">
+                            Leave blank to hide the embedded webcam on the Control tab.
+                        </div>
+                    </div>
+                </form>
+
                 <div class="card">
                     <div class="card">
                         <div class="card-header fs-4">

--- a/tests/test_filetransfer.py
+++ b/tests/test_filetransfer.py
@@ -1,0 +1,61 @@
+import unittest
+from queue import Empty
+from types import SimpleNamespace
+
+from web.service.filetransfer import FileTransferService
+
+
+class FakeQueue:
+    def __init__(self, result=None, fail=False):
+        self.result = result
+        self.fail = fail
+        self.timeout = None
+
+    def get(self, timeout=None):
+        self.timeout = timeout
+        if self.fail:
+            raise Empty
+        return self.result
+
+
+class FileTransferTimeoutTests(unittest.TestCase):
+    def test_acknowledgement_is_bounded(self):
+        queue = FakeQueue(fail=True)
+        service = SimpleNamespace(
+            _tap=queue,
+            api_aabb=lambda *args, **kwargs: None,
+        )
+
+        with self.assertRaisesRegex(ConnectionError, "offset 32768"):
+            FileTransferService.api_aabb_request(
+                service,
+                api=object(),
+                frametype=object(),
+                msg=b"block",
+                pos=32768,
+            )
+
+        self.assertEqual(queue.timeout, 15)
+
+    def test_acknowledgement_returns_normally(self):
+        response = object()
+        queue = FakeQueue(result=response)
+        service = SimpleNamespace(
+            _tap=queue,
+            api_aabb=lambda *args, **kwargs: None,
+            name="FileTransferService",
+        )
+
+        FileTransferService.api_aabb_request(
+            service,
+            api=object(),
+            frametype=object(),
+            msg=b"block",
+            pos=0,
+        )
+
+        self.assertEqual(queue.timeout, 15)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_preprint.py
+++ b/tests/test_preprint.py
@@ -1,0 +1,166 @@
+import contextlib
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from web import util
+
+
+class FakeClient:
+    def __init__(self, replies=None):
+        self.commands = []
+        self.replies = list(replies or [])
+        self._mqtt = SimpleNamespace(disconnect=lambda: None)
+
+    def command(self, payload):
+        self.commands.append(payload["cmdData"])
+
+    def fetch(self, timeout):
+        if self.replies:
+            reply = self.replies.pop(0)
+        else:
+            reply = {"commandType": util._GCODE_COMMAND, "reply": 0, "resData": "ok"}
+        return [(None, [reply])]
+
+
+class FakeFileTransfer:
+    def __init__(self):
+        self.data = None
+        self.filename = None
+        self.user_name = None
+
+    def send_file(self, upload, user_name):
+        self.data = upload.read()
+        self.filename = upload.filename
+        self.user_name = user_name
+
+
+class FakeServiceManager:
+    def __init__(self, filetransfer):
+        self.filetransfer = filetransfer
+
+    @contextlib.contextmanager
+    def borrow(self, name):
+        assert name == "filetransfer"
+        yield self.filetransfer
+
+
+class PreprintTests(unittest.TestCase):
+    def test_extracts_resolved_temperatures(self):
+        data = b"M104 S150\nM190 S55\nM109 S220\nG28\n"
+        self.assertEqual(util.extract_preprint_temperatures(data), (55, 220))
+
+    def test_rejects_unresolved_or_unsafe_temperatures(self):
+        with self.assertRaisesRegex(ValueError, "could not find M190"):
+            util.extract_preprint_temperatures(
+                b"M190 S{first_layer_bed_temperature[0]}\nM109 S220\n"
+            )
+        with self.assertRaisesRegex(ValueError, "unsafe M109"):
+            util.extract_preprint_temperatures(b"M190 S55\nM109 S500\n")
+
+    def test_runs_preprint_before_preserving_upload(self):
+        client = FakeClient(
+            replies=[
+                {"commandType": util._GCODE_COMMAND, "reply": 0, "resData": "ok"},
+                {"commandType": util._GCODE_COMMAND, "reply": 0, "resData": "ok"},
+                {"commandType": util._BED_TEMPERATURE, "currentTemp": 5500},
+                {"commandType": util._GCODE_COMMAND, "reply": 0, "resData": "ok"},
+                {"commandType": util._NOZZLE_TEMPERATURE, "currentTemp": 22000},
+                {"commandType": util._GCODE_COMMAND, "reply": 0, "resData": "ok"},
+            ]
+        )
+        filetransfer = FakeFileTransfer()
+        app = SimpleNamespace(
+            config={
+                "config": object(),
+                "printer_index": 0,
+                "insecure": False,
+                "preprint_command_timeout": 300,
+            },
+            svc=FakeServiceManager(filetransfer),
+        )
+        data = b"M190 S55\nM109 S220\nG28\n"
+
+        util._PREPRINT_LOCK.acquire()
+        with patch("web.util.cli.mqtt.mqtt_open", return_value=client):
+            util._run_preprint_upload(
+                app,
+                data,
+                "test.gcode",
+                "OrcaSlicer",
+                55,
+                220,
+            )
+
+        self.assertEqual(
+            client.commands,
+            [
+                "M104 S150",
+                "M400",
+                "M140 S55",
+                "M400",
+                "M104 S220",
+                "M400",
+                "G36",
+                "M400",
+            ],
+        )
+        self.assertEqual(filetransfer.data, data)
+        self.assertEqual(filetransfer.filename, "test.gcode")
+        self.assertEqual(filetransfer.user_name, "OrcaSlicer")
+        self.assertFalse(util._PREPRINT_LOCK.locked())
+
+    def test_failure_cools_down_and_does_not_upload(self):
+        client = FakeClient(
+            replies=[
+                {"commandType": util._GCODE_COMMAND, "reply": 0, "resData": "ok"},
+                {
+                    "commandType": util._GCODE_COMMAND,
+                    "reply": 1,
+                    "resData": "Error: heating failed",
+                },
+                {"commandType": util._GCODE_COMMAND, "reply": 0, "resData": "ok"},
+                {"commandType": util._GCODE_COMMAND, "reply": 0, "resData": "ok"},
+            ]
+        )
+        filetransfer = FakeFileTransfer()
+        app = SimpleNamespace(
+            config={
+                "config": object(),
+                "printer_index": 0,
+                "insecure": False,
+                "preprint_command_timeout": 300,
+            },
+            svc=FakeServiceManager(filetransfer),
+        )
+
+        util._PREPRINT_LOCK.acquire()
+        with patch("web.util.cli.mqtt.mqtt_open", return_value=client):
+            util._run_preprint_upload(
+                app,
+                b"data",
+                "test.gcode",
+                "OrcaSlicer",
+                55,
+                220,
+            )
+
+        self.assertEqual(
+            client.commands,
+            [
+                "M104 S150",
+                "M400",
+                "M140 S55",
+                "M400",
+                "M104 S0",
+                "M400",
+                "M140 S0",
+                "M400",
+            ],
+        )
+        self.assertIsNone(filetransfer.data)
+        self.assertFalse(util._PREPRINT_LOCK.locked())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_web_ui.py
+++ b/tests/test_web_ui.py
@@ -1,0 +1,200 @@
+import contextlib
+import io
+import json
+import unittest
+from datetime import datetime
+from types import SimpleNamespace
+from unittest import mock
+
+from cli.model import Account, Config, Printer
+from web import app, _require_token, ctrl_send_mqtt
+
+
+class FakeConfigManager:
+
+    def __init__(self, cfg):
+        self.cfg = cfg
+
+    @contextlib.contextmanager
+    def open(self):
+        yield self.cfg
+
+    @contextlib.contextmanager
+    def modify(self):
+        yield self.cfg
+
+
+class FakeSocket:
+
+    def __init__(self, messages):
+        self.messages = messages
+        self.sent = []
+
+    def receive(self):
+        if self.messages:
+            return self.messages.pop(0)
+        return None
+
+    def send(self, payload):
+        self.sent.append(payload)
+
+
+def make_config(webcam_url=""):
+    return Config(
+        account=Account(
+            auth_token="auth-token",
+            region="us",
+            user_id="user-id",
+            email="test@example.com",
+            country="US",
+        ),
+        printers=[
+            Printer(
+                id="1",
+                sn="SN123",
+                name="Test Printer",
+                model="V8111",
+                create_time=datetime.now(),
+                update_time=datetime.now(),
+                wifi_mac="00:11:22:33:44:55",
+                ip_addr="192.168.1.10",
+                mqtt_key=b"\x01\x02",
+                api_hosts=[],
+                p2p_hosts=[],
+                p2p_duid="DUID123",
+                p2p_key="key",
+            )
+        ],
+        webcam_url=webcam_url,
+    )
+
+
+class WebUiTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.client = app.test_client()
+        self.old_testing = app.config.get("TESTING")
+        self.old_access_token = app.config.get("access_token")
+        self.old_config = app.config.get("config")
+        self.old_login = app.config.get("login")
+        self.old_video_supported = app.config.get("video_supported")
+        self.old_printer_index = app.config.get("printer_index")
+        self.old_webcam_url = app.config.get("webcam_url")
+
+        app.config["TESTING"] = True
+        app.config["config"] = FakeConfigManager(make_config())
+        app.config["login"] = True
+        app.config["video_supported"] = False
+        app.config["printer_index"] = 0
+        app.config["webcam_url"] = ""
+
+    def tearDown(self):
+        app.config["TESTING"] = self.old_testing
+        app.config["access_token"] = self.old_access_token
+        app.config["config"] = self.old_config
+        app.config["login"] = self.old_login
+        app.config["video_supported"] = self.old_video_supported
+        app.config["printer_index"] = self.old_printer_index
+        app.config["webcam_url"] = self.old_webcam_url
+
+    def test_root_without_token_is_available(self):
+        app.config["access_token"] = ""
+
+        resp = self.client.get("/")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(b"control-tab", resp.data)
+
+    def test_login_flow_and_exempt_routes(self):
+        app.config["access_token"] = "shared-secret"
+        app.config["config"] = FakeConfigManager(make_config(webcam_url="http://camera.local/mjpg"))
+
+        resp = self.client.get("/")
+        self.assertEqual(resp.status_code, 302)
+        self.assertIn("/login?next=/", resp.location)
+
+        resp = self.client.get(resp.location)
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(b"Access token required", resp.data)
+
+        resp = self.client.post("/login?next=/", data={"token": "wrong", "next": "/"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(b"Invalid token", resp.data)
+
+        resp = self.client.post("/login?next=/", data={"token": "shared-secret", "next": "/"}, follow_redirects=True)
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(b"GCode Terminal", resp.data)
+        self.assertIn(b"http://camera.local/mjpg", resp.data)
+
+        version_resp = self.client.get("/api/version")
+        self.assertEqual(version_resp.status_code, 200)
+        self.assertEqual(version_resp.json["server"], "1.9.0")
+
+        with mock.patch("web.util.upload_file_to_printer") as upload_file:
+            upload_resp = self.client.post(
+                "/api/files/local",
+                data={
+                    "print": "true",
+                    "file": (io.BytesIO(b"G1 X1\n"), "test.gcode"),
+                },
+                content_type="multipart/form-data",
+            )
+        self.assertEqual(upload_resp.status_code, 200)
+        upload_file.assert_called_once()
+
+    def test_webcam_setting_persists_in_config(self):
+        app.config["access_token"] = "shared-secret"
+
+        with self.client.session_transaction() as sess:
+            sess["authed"] = True
+
+        resp = self.client.post("/api/ankerctl/config/webcam", data={"webcam_url": "http://cam/new.mjpg"})
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(app.config["config"].cfg.webcam_url, "http://cam/new.mjpg")
+
+    def test_ws_ctrl_requires_auth_when_token_enabled(self):
+        app.config["access_token"] = "shared-secret"
+
+        with app.test_request_context("/ws/ctrl"):
+            result = _require_token()
+
+        self.assertEqual(result[1], 401)
+
+    def test_ws_ctrl_gcode_command_round_trip(self):
+        app.config["access_token"] = ""
+
+        fake_client = mock.Mock()
+        fake_client.await_response.return_value = {
+            "commandType": 0x0413,
+            "resData": "ok",
+        }
+        fake_socket = FakeSocket([])
+        message = {
+            "mqtt": {
+                "commandType": 0x0413,
+                "cmdData": "M104 S60",
+                "cmdLen": 8,
+            },
+            "awaitResponse": True,
+        }
+
+        @contextlib.contextmanager
+        def fake_borrow(name):
+            self.assertEqual(name, "mqttqueue")
+            yield SimpleNamespace(client=fake_client)
+
+        with mock.patch.object(app.svc, "borrow", fake_borrow):
+            ctrl_send_mqtt(fake_socket, message)
+
+        fake_client.command.assert_called_once_with({
+            "commandType": 0x0413,
+            "cmdData": "M104 S60",
+            "cmdLen": 8,
+        })
+        fake_client.await_response.assert_called_once_with(0x0413)
+        self.assertEqual(json.loads(fake_socket.sent[0])["mqttReply"]["resData"], "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -26,12 +26,15 @@ Services:
     - util: Houses utility services for use in the web module
     - config: Handles configuration manipulation for ankerctl
 """
+import hmac
+import os
 import json
 import logging as log
 
 from datetime import datetime
 from secrets import token_urlsafe as token
-from flask import Flask, flash, request, render_template, Response, session, url_for, jsonify
+from urllib.parse import urlsplit
+from flask import Flask, flash, request, render_template, Response, session, url_for, jsonify, redirect
 from flask_sock import Sock
 from user_agents import parse as user_agent_parse
 
@@ -49,12 +52,111 @@ import cli.countrycodes
 
 
 app = Flask(__name__, root_path=ROOT_DIR, static_folder="static", template_folder="static")
-# secret_key is required for flash() to function
-app.secret_key = token(24)
+# secret_key is required for flash() to function.
+# ANKERCTL_SECRET_KEY keeps login sessions valid across restarts; otherwise a
+# fresh random key is generated (and users must re-login after a restart).
+app.secret_key = os.environ.get("ANKERCTL_SECRET_KEY") or token(24)
 app.config.from_prefixed_env()
+
+# Optional shared-secret access token. When set, the human web UI requires
+# login; when empty, auth is disabled (preserving previous behaviour). The
+# slicer/OctoPrint upload endpoints are always exempt (see _require_token).
+app.config["access_token"] = os.environ.get("ANKERCTL_TOKEN", "")
+
+# Optional external webcam stream URL (e.g. MJPEG from a phone/USB cam),
+# embedded on the Control tab. Empty = hidden.
+app.config["webcam_url"] = os.environ.get("ANKERCTL_WEBCAM_URL", "")
+
+# When enabled, Orca uploads are held while ankerctl preheats the printer and
+# invokes the M5C firmware's G36 preparation routine over MQTT. G36 is sent
+# out-of-band because the printer rejects it when embedded in uploaded G-code.
+app.config["preprint_g36"] = os.environ.get(
+    "ANKERCTL_PREPRINT_G36", ""
+).lower() in {"1", "true", "yes", "on"}
+app.config["preprint_command_timeout"] = int(
+    os.environ.get("ANKERCTL_PREPRINT_COMMAND_TIMEOUT", "300")
+)
+
 app.svc = ServiceManager()
 
 sock = Sock(app)
+
+
+# Paths always reachable without a login token: the OctoPrint upload API used
+# by slicers (Orca/PrusaSlicer), version probe, the login page itself, and
+# static assets needed to render it.
+AUTH_EXEMPT_EXACT = {"/api/version", "/login"}
+AUTH_EXEMPT_PREFIX = ("/static/", "/api/files/local")
+
+
+def _auth_enabled():
+    return bool(app.config.get("access_token"))
+
+
+def _auth_is_valid():
+    if not _auth_enabled():
+        return True
+    return bool(session.get("authed"))
+
+
+def _auth_safe_next():
+    if request.query_string:
+        return request.full_path.removesuffix("?")
+    return request.path
+
+
+def _auth_safe_redirect_target(target):
+    if not target:
+        return url_for("app_root")
+    parts = urlsplit(target)
+    if parts.scheme or parts.netloc or not target.startswith("/"):
+        return url_for("app_root")
+    return target
+
+
+@app.before_request
+def _require_token():
+    """
+    Gate the web UI behind a shared token when ANKERCTL_TOKEN is set. Slicer
+    upload endpoints stay open so 'Send and Print' keeps working without auth.
+    """
+    required = app.config.get("access_token")
+    if not required:
+        return
+
+    path = request.path
+    if path in AUTH_EXEMPT_EXACT or path.startswith(AUTH_EXEMPT_PREFIX):
+        return
+
+    if _auth_is_valid():
+        return
+
+    # Websocket handshakes can't follow a redirect; reject outright.
+    if path.startswith("/ws/"):
+        return "Unauthorized", 401
+
+    return redirect(url_for("app_login", next=_auth_safe_next()))
+
+
+@app.route("/login", methods=["GET", "POST"])
+def app_login():
+    """
+    Minimal token login. Sets a session cookie on success. If no token is
+    configured, auth is disabled and we redirect straight to the app.
+    """
+    required = app.config.get("access_token")
+    if not required:
+        return redirect(url_for("app_root"))
+
+    next_url = _auth_safe_redirect_target(request.values.get("next"))
+
+    if request.method == "POST":
+        if hmac.compare_digest(request.form.get("token", ""), required):
+            session["authed"] = True
+            return redirect(next_url)
+        flash("Invalid token", "danger")
+
+    return render_template("login.html", next_url=next_url)
 
 
 # autopep8: off
@@ -68,11 +170,23 @@ import web.service.filetransfer
 PRINTERS_WITHOUT_CAMERA = ["V8110"]
 
 
+def ctrl_send_mqtt(sock, msg):
+    with app.svc.borrow("mqttqueue") as mq:
+        mq.client.command(msg["mqtt"])
+        if msg.get("awaitResponse"):
+            sock.send(json.dumps({
+                "commandType": msg["mqtt"]["commandType"],
+                "mqttReply": mq.client.await_response(msg["mqtt"]["commandType"]),
+            }))
+
+
 @sock.route("/ws/mqtt")
 def mqtt(sock):
     """
     Handles receiving and sending messages on the 'mqttqueue' stream service through websocket
     """
+    if not _auth_is_valid():
+        return
     if not app.config["login"]:
         return
     for data in app.svc.stream("mqttqueue"):
@@ -85,6 +199,8 @@ def video(sock):
     """
     Handles receiving and sending messages on the 'videoqueue' stream service through websocket
     """
+    if not _auth_is_valid():
+        return
     if not app.config["login"] or not app.config["video_supported"]:
         return
     for msg in app.svc.stream("videoqueue"):
@@ -96,6 +212,8 @@ def pppp_state(sock):
     """
     Handles a status request for the 'pppp' stream service through websocket
     """
+    if not _auth_is_valid():
+        return
     if not app.config["login"]:
         return
 
@@ -125,6 +243,8 @@ def ctrl(sock):
     """
     Handles controlling of light and video quality through websocket
     """
+    if not _auth_is_valid():
+        return
     if not app.config["login"]:
         return
 
@@ -132,11 +252,13 @@ def ctrl(sock):
     sock.send(json.dumps({"ankerctl": 1}))
 
     while True:
-        msg = json.loads(sock.receive())
+        payload = sock.receive()
+        if payload is None:
+            return
+        msg = json.loads(payload)
 
         if "mqtt" in msg:
-            with app.svc.borrow("mqttqueue") as mq:
-                mq.client.command(msg["mqtt"])
+            ctrl_send_mqtt(sock, msg)
 
         if "light" in msg:
             with app.svc.borrow("videoqueue") as vq:
@@ -179,6 +301,7 @@ def app_root():
     with config.open() as cfg:
         user_agent = user_agent_parse(request.headers.get("User-Agent"))
         user_os = web.platform.os_platform(user_agent.os.family)
+        webcam_url = cfg.webcam_url or app.config["webcam_url"]
 
         if cfg:
             anker_config = str(web.config.config_show(cfg))
@@ -211,6 +334,7 @@ def app_root():
             config_existing_email=config_existing_email,
             country_codes=json.dumps(cli.countrycodes.country_codes),
             current_country=country,
+            webcam_url=webcam_url,
             printer=printer
         )
 
@@ -292,6 +416,15 @@ def app_api_ankerctl_config_upload():
     except Exception as err:
         log.exception(f"Config import failed: {err}")
         return web.util.flash_redirect(url_for('app_root'), f"Unexpected Error occurred: {err}", "danger")
+
+
+@app.post("/api/ankerctl/config/webcam")
+def app_api_ankerctl_config_webcam():
+    with app.config["config"].modify() as cfg:
+        cfg.webcam_url = request.form.get("webcam_url", "").strip()
+
+    message = "Webcam URL saved" if cfg.webcam_url else "Webcam URL cleared"
+    return web.util.flash_redirect(url_for('app_root'), message, "success")
 
 
 @app.post("/api/ankerctl/config/login")

--- a/web/service/filetransfer.py
+++ b/web/service/filetransfer.py
@@ -2,6 +2,7 @@ import uuid
 import logging as log
 
 from multiprocessing import Queue
+from queue import Empty
 
 from ..lib.service import Service
 from .. import app
@@ -13,6 +14,9 @@ import cli.mqtt
 import cli.util
 
 
+FILE_TRANSFER_ACK_TIMEOUT = 15
+
+
 class FileTransferService(Service):
 
     def api_aabb(self, api, frametype, msg=b"", pos=0):
@@ -20,7 +24,12 @@ class FileTransferService(Service):
 
     def api_aabb_request(self, api, frametype, msg=b"", pos=0):
         self.api_aabb(api, frametype, msg, pos)
-        resp = self._tap.get()
+        try:
+            resp = self._tap.get(timeout=FILE_TRANSFER_ACK_TIMEOUT)
+        except Empty as exc:
+            raise ConnectionError(
+                f"Timed out waiting for file-transfer acknowledgement at offset {pos}"
+            ) from exc
         log.debug(f"{self.name}: Aabb response: {resp}")
 
     def send_file(self, fd, user_name):

--- a/web/util.py
+++ b/web/util.py
@@ -1,4 +1,23 @@
+import io
+import logging as log
+import re
+import time
+from threading import Lock, Thread
+
 from flask import flash, redirect, request
+
+import cli.mqtt
+from libflagship.mqtt import MqttMsgType
+
+
+_PREPRINT_LOCK = Lock()
+_GCODE_COMMAND = MqttMsgType.ZZ_MQTT_CMD_GCODE_COMMAND.value
+_NOZZLE_TEMPERATURE = MqttMsgType.ZZ_MQTT_CMD_NOZZLE_TEMP.value
+_BED_TEMPERATURE = MqttMsgType.ZZ_MQTT_CMD_HOTBED_TEMP.value
+_TEMPERATURE_LIMITS = {
+    "M190": (1, 130),
+    "M109": (150, 320),
+}
 
 
 def flash_redirect(path: str, message: str | None = None, category="info"):
@@ -26,6 +45,146 @@ def flash_redirect(path: str, message: str | None = None, category="info"):
     return redirect(path)
 
 
+def extract_preprint_temperatures(data: bytes) -> tuple[int, int]:
+    """Extract the resolved first-layer bed and nozzle temperatures."""
+    text = data[:256 * 1024].decode("utf-8", errors="ignore")
+    temperatures = {}
+
+    for command, limits in _TEMPERATURE_LIMITS.items():
+        match = re.search(
+            rf"(?im)^\s*{command}\b[^\r\n;]*?\b[SR]\s*(-?\d+(?:\.\d+)?)",
+            text,
+        )
+        if not match:
+            raise ValueError(f"Pre-print hook could not find {command} temperature")
+
+        value = round(float(match.group(1)))
+        if not limits[0] <= value <= limits[1]:
+            raise ValueError(
+                f"Pre-print hook rejected unsafe {command} temperature: {value}C"
+            )
+        temperatures[command] = value
+
+    return temperatures["M190"], temperatures["M109"]
+
+
+def _send_gcode(client, command: str, timeout: int) -> dict:
+    def send(value):
+        client.command({
+            "commandType": _GCODE_COMMAND,
+            "cmdData": value,
+            "cmdLen": len(value),
+        })
+
+    log.info("Pre-print hook: sending %s", command)
+    send(command)
+    # G-code commands first receive an "echo:busy" reply. M400 is queued
+    # behind the command and supplies the terminal "ok" only after all prior
+    # heating and motion have completed.
+    send("M400")
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        remaining = deadline - time.monotonic()
+        for _, body in client.fetch(timeout=min(1, remaining)):
+            for reply in body:
+                if reply.get("commandType") != _GCODE_COMMAND:
+                    continue
+
+                response = str(reply.get("resData", ""))
+                lowered = response.lower()
+                if any(
+                    marker in lowered
+                    for marker in ("error", "unknown", "failed")
+                ):
+                    raise RuntimeError(
+                        f"Pre-print command failed ({command}): {response}"
+                    )
+                if reply.get("reply") == 0 and "ok" in lowered:
+                    return reply
+
+    raise TimeoutError(f"Timed out waiting for pre-print command: {command}")
+
+
+def _cool_down(client):
+    for command in ("M104 S0", "M140 S0"):
+        try:
+            _send_gcode(client, command, timeout=10)
+        except Exception:
+            log.exception("Pre-print hook: failed to send emergency cooldown command")
+
+
+def _wait_for_temperature(client, command_type, target, tolerance, timeout):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        remaining = deadline - time.monotonic()
+        for _, body in client.fetch(timeout=min(1, remaining)):
+            for message in body:
+                if message.get("commandType") != command_type:
+                    continue
+                current = float(message["currentTemp"]) / 100
+                if current >= target - tolerance:
+                    log.info(
+                        "Pre-print hook: temperature reached %.1fC / %dC",
+                        current,
+                        target,
+                    )
+                    return
+
+    raise TimeoutError(f"Timed out waiting for temperature: {target}C")
+
+
+def _disconnect_mqtt(client):
+    try:
+        client._mqtt.disconnect()
+    except Exception:
+        log.exception("Pre-print hook: failed to disconnect MQTT client")
+
+
+def _run_preprint_upload(app, data, filename, user_name, bed_temp, nozzle_temp):
+    client = None
+    try:
+        client = cli.mqtt.mqtt_open(
+            app.config["config"],
+            app.config["printer_index"],
+            app.config["insecure"],
+        )
+
+        timeout = int(app.config.get("preprint_command_timeout", 300))
+        _send_gcode(client, "M104 S150", timeout=30)
+        _send_gcode(client, f"M140 S{bed_temp}", timeout=30)
+        _wait_for_temperature(
+            client,
+            _BED_TEMPERATURE,
+            bed_temp,
+            tolerance=0.5,
+            timeout=timeout,
+        )
+        _send_gcode(client, f"M104 S{nozzle_temp}", timeout=30)
+        _wait_for_temperature(
+            client,
+            _NOZZLE_TEMPERATURE,
+            nozzle_temp,
+            tolerance=1,
+            timeout=timeout,
+        )
+        _send_gcode(client, "G36", timeout=timeout)
+
+        upload = io.BytesIO(data)
+        upload.filename = filename
+        with app.svc.borrow("filetransfer") as filetransfer:
+            filetransfer.send_file(upload, user_name)
+        log.info("Pre-print hook: completed routine and uploaded %r", filename)
+    except Exception:
+        log.exception("Pre-print hook: failed for %r", filename)
+        if client is not None:
+            _cool_down(client)
+    finally:
+        if client is not None:
+            _disconnect_mqtt(client)
+        _PREPRINT_LOCK.release()
+
+
 def upload_file_to_printer(app, file):
     """ This function uploads a file to the printer.
 
@@ -34,6 +193,33 @@ def upload_file_to_printer(app, file):
         - file (file-like object): The file to be uploaded to the printer.
     """
     user_name = request.headers.get("User-Agent", "ankerctl").split("/")[0]
+
+    if app.config.get("preprint_g36"):
+        data = file.read()
+        bed_temp, nozzle_temp = extract_preprint_temperatures(data)
+        if not _PREPRINT_LOCK.acquire(blocking=False):
+            raise ConnectionError("A pre-print routine is already running")
+
+        worker = Thread(
+            target=_run_preprint_upload,
+            args=(
+                app,
+                data,
+                file.filename,
+                user_name,
+                bed_temp,
+                nozzle_temp,
+            ),
+            name="ankerctl-preprint",
+            daemon=True,
+        )
+        try:
+            worker.start()
+        except Exception:
+            _PREPRINT_LOCK.release()
+            raise
+        log.info("Pre-print hook: queued %r", file.filename)
+        return
 
     with app.svc.borrow("filetransfer") as ft:
         ft.send_file(file, user_name)


### PR DESCRIPTION
# Web UI auth, Control tab, external webcam, and pre-print G36 hook

## Summary

- **Optional token login for the web UI.** Setting `ANKERCTL_TOKEN` gates the UI and websockets behind a shared-secret login page (`/login`, constant-time compare, session cookie). The OctoPrint-compatible slicer endpoints (`/api/version`, `/api/files/local`) stay open so Orca/PrusaSlicer "Send and Print" keeps working without credentials. `ANKERCTL_SECRET_KEY` optionally pins the Flask session key so logins survive restarts. With no token set, behaviour is unchanged (no auth).
- **New Control tab.** Printer state, nozzle/bed temperatures with set forms, jog/home controls, part-fan slider, pause/resume/stop, object preview with progress overlay, and a gcode terminal. Commands go over the existing `/ws/ctrl` websocket, which now supports awaiting the MQTT reply and returns cleanly when the client disconnects. Also fixes the malformed `/ws/ctrl` URL (missing `//`). Note: the pause/resume/stop `PRINT_CONTROL` values are best-guess and marked TODO in `ankersrv.js`.
- **External webcam URL.** A new config field (editable on the Setup tab, or via `ANKERCTL_WEBCAM_URL`) embeds an external stream (e.g. MediaMTX WebRTC / MJPEG) on the Live tab for printers without a usable built-in camera. The value survives config re-import/upgrade.
- **Optional pre-print G36 hook.** With `ANKERCTL_PREPRINT_G36` enabled, slicer uploads are held while ankerctl preheats bed and nozzle (temperatures parsed from the uploaded gcode and validated against safe limits) and runs the M5C firmware's G36 preparation routine over MQTT before transferring the file. G36 is sent out-of-band because the printer rejects it embedded in uploaded gcode. Any failure triggers a cooldown (`M104 S0` / `M140 S0`).
- **File-transfer robustness.** The upload acknowledgement wait now times out after 15s and raises `ConnectionError` instead of hanging the upload thread forever on a lost PPPP ack.
- **Docs.** README notes for the token, plus a runbook (`documentation/local-macos-service.md`) for running ankerctl as a macOS launchd service with OrcaSlicer, Tailscale, and an iPad WebRTC camera.

## New environment variables (all optional, default = previous behaviour)

| Variable | Effect |
| --- | --- |
| `ANKERCTL_TOKEN` | Require this token to use the web UI |
| `ANKERCTL_SECRET_KEY` | Stable Flask session key (logins survive restarts) |
| `ANKERCTL_WEBCAM_URL` | External webcam stream embedded in the UI |
| `ANKERCTL_PREPRINT_G36` | Enable the pre-print heat + G36 routine on slicer uploads |
| `ANKERCTL_PREPRINT_COMMAND_TIMEOUT` | Pre-print command timeout in seconds (default 300) |

## Testing

- New `tests/` suite (11 tests, all passing): login flow and exempt slicer routes, webcam config persistence, `/ws/ctrl` auth gating and gcode round-trip, pre-print temperature extraction/limit validation, and the file-transfer ack timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDdU5AaAd6D4WYiEpLxb6U
